### PR TITLE
fix: add gunicorn to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flasgger==0.9.5
 Flask==1.1.2
+gunicorn==20.0.4
 pytest==6.2.1
 python-semantic-release==7.11.0


### PR DESCRIPTION
**Technical Description**

Fix `gunicorn command not found` issue

**Reference**

Issue: https://github.com/Eorate/swiftflame/issues/12