### PR TITLE
chore: Specify git username and email

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,4 +77,6 @@ workflows:
                 name: Running post-deploy
                 command: |
                   /usr/bin/python3 -m pip install -r requirements.txt
+                  git config user.email "Tharlaw@example.com"
+                  git config user.name "Tharlaw"
                   semantic-release publish


### PR DESCRIPTION


**Technical Description**

When running the post-deploy, semantic-release needs a git username and
email configured for it to use

**Reference**

Trello: https://trello.com/c/0RDqOA3u/1-initial-project-setup