### PR TITLE
Develop: Specify git username and email (semantic-release)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,4 +77,6 @@ workflows:
                 name: Running post-deploy
                 command: |
                   /usr/bin/python3 -m pip install -r requirements.txt
+                  git config user.email "Tharlaw@example.com"
+                  git config user.name "Tharlaw"
                   semantic-release publish


### PR DESCRIPTION
**Technical Description**

semantic-release requires a git user name and email configured for it to use. None is configured in circleci.
